### PR TITLE
feat(blog): implement contextual related posts and fix image warnings

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -12,7 +12,7 @@ export default async function PostPage({ params }: PostPageProps) {
   const { slug } = await params;
   const [post, relatedPosts] = await Promise.all([
     getPostBySlug(slug),
-    getRelatedPosts(slug, 3)
+    getRelatedPosts(slug)
   ]);
   if (!post) {
     notFound();
@@ -64,7 +64,7 @@ export default async function PostPage({ params }: PostPageProps) {
             alt={post.title ?? "Post cover"}
             width={800}
             height={450}
-            className="w-full h-auto"
+            style={{ width: '100%', height: 'auto' }}
             priority
           />
           <div className="mt-1 text-xs text-zinc-500 italic">
@@ -106,13 +106,13 @@ export default async function PostPage({ params }: PostPageProps) {
                 className="flex flex-col bg-zinc-950 rounded-lg overflow-hidden border border-zinc-800 hover:border-zinc-700 transition-colors"
               >
                 {relatedPost.mainImage && (
-                  <div className="aspect-video w-full overflow-hidden">
+                  <div className="aspect-video w-full overflow-hidden relative">
                     <Image
-                      width={100}
-                      height={100}
+                      fill
                       src={relatedPost.mainImage}
                       alt={relatedPost.title ?? "Blog post cover"}
-                      className="w-full h-full object-cover"
+                      className="object-cover"
+                      sizes="(max-width: 768px) 100vw, 33vw"
                     />
                   </div>
                 )}

--- a/lib/sanity.ts
+++ b/lib/sanity.ts
@@ -167,10 +167,10 @@ export async function getRecentBlogPosts(limit: number = 3): Promise<BlogPost[]>
   return (data || []);
 }
 
-export async function getRelatedPosts(currentSlug: string, limit: number = 3): Promise<RelatedPost[]> {
+export async function getRelatedPosts(currentSlug: string): Promise<RelatedPost[]> {
   'use cache'
   cacheLife('hours')
-  const query = `*[_type == "post" && featured == true && slug.current != $currentSlug && dateTime(publishedAt) <= dateTime(now())] | order(publishedAt desc) [0...$limit] {
+  const query = `*[_type == "post" && featured == true && dateTime(publishedAt) <= dateTime(now())] | order(publishedAt desc) {
     _id,
     title,
     "slug": slug.current,
@@ -178,8 +178,39 @@ export async function getRelatedPosts(currentSlug: string, limit: number = 3): P
     "mainImage": mainImage.asset->url,
     "categories": categories[]->{ title }
   }`;
-  const data = await client.fetch(query, { currentSlug, limit });
-  return (data || []);
+  const data: RelatedPost[] = await client.fetch(query);
+
+  if (!data || data.length < 4) {
+    return [];
+  }
+
+  const currentIndex = data.findIndex((post) => post.slug === currentSlug);
+
+  if (currentIndex === -1) {
+    return [];
+  }
+
+  let selectedIndices: number[];
+
+  if (currentIndex === 0) {
+    // Reading the latest post: take the next 3 oldest
+    selectedIndices = [1, 2, 3];
+  } else if (currentIndex === 1) {
+    // Reading the 2nd latest: take the 1st, then the next 2 oldest from current
+    selectedIndices = [0, 2, 3];
+  } else {
+    // Reading 3rd or older: take the 1st, 2nd, and the next oldest from current
+    selectedIndices = [0, 1, currentIndex + 1];
+  }
+
+  // Ensure all selected indices are within bounds
+  const validIndices = selectedIndices.filter((i) => i < data.length);
+
+  if (validIndices.length !== 3) {
+    return [];
+  }
+
+  return validIndices.map((i) => data[i]);
 }
 
 export async function getBlogPostCount(): Promise<number> {


### PR DESCRIPTION
lib/sanity.ts
- Rewrote getRelatedPosts() to return contextually relevant featured posts
  instead of always taking the top 3.
- The function now fetches ALL featured posts sorted by publishedAt desc,
  finds the current post's index, and selects 3 neighbors based on position:
    • Reading latest post (index 0): returns indices [1, 2, 3]
    • Reading 2nd latest (index 1): returns indices [0, 2, 3]
    • Reading 3rd or older (index ≥ 2): returns indices [0, 1,
currentIndex+1]
- Returns an empty array if fewer than 4 total featured posts exist, or if
  fewer than 3 valid neighbors can be selected. This allows the UI to hide
  the "Continue Reading" section when there is nothing meaningful to show.
- Removed the `limit` parameter from the function signature since the neighbor-selection logic now determines the result set size internally.
app/blog/[slug]/page.tsx
- Updated getRelatedPosts(slug, 3) call to getRelatedPosts(slug) to match
  the new signature.
- Fixed Next.js Image aspect ratio warning on the main post cover image by replacing `className="w-full h-auto"` with an inline `style` prop `style={{ width: '100%', height: 'auto' }}`.
- Fixed Next.js Image aspect ratio warning on related post card images by replacing explicit `width={100} height={100}` with the `fill` prop. Added `relative` positioning to the parent `aspect-video` container and included `sizes="(max-width: 768px) 100vw, 33vw"` for responsive image optimization.