### PR TITLE
fix: resolve build warnings and add disclaimers to blog pages

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -21,7 +21,13 @@ export default async function BlogPage() {
         </span>
       </h1>
       <BlogList posts={posts} />
+
       <Pagination currentPage={1} totalPages={totalPages} />
+      <div className="mt-12 pt-6 border-t border-zinc-200 dark:border-zinc-800">
+        <p className="text-xs text-zinc-500 dark:text-zinc-400 italic">
+          Disclaimer: All content reflects my personal views only and does not represent the positions, strategies, or opinions of any entity I am or have been associated with.
+        </p>
+      </div>
     </div>
   );
 }

--- a/app/blog/page/[page]/page.tsx
+++ b/app/blog/page/[page]/page.tsx
@@ -27,7 +27,13 @@ export default async function BlogPage({
         </span>
       </h1>
       <BlogList posts={posts} />
+
       <Pagination currentPage={currentPage} totalPages={totalPages} />
+      <div className="mt-12 pt-6 border-t border-zinc-200 dark:border-zinc-800">
+        <p className="text-xs text-zinc-500 dark:text-zinc-400 italic">
+          Disclaimer: All content reflects my personal views only and does not represent the positions, strategies, or opinions of any entity I am or have been associated with.
+        </p>
+      </div>
     </div>
   );
 }

--- a/components/PortableTextComponents.tsx
+++ b/components/PortableTextComponents.tsx
@@ -114,4 +114,11 @@ export const portableTextComponents: PortableTextComponents = {
     code: CodeBlock,
     image: SanityImage,
   },
+  block: {
+    code: ({ children }) => (
+      <pre className="overflow-x-auto rounded-lg bg-zinc-100 dark:bg-zinc-800 p-4 my-4">
+        <code className="text-sm text-zinc-800 dark:text-zinc-200">{children}</code>
+      </pre>
+    ),
+  },
 };

--- a/lib/sanity.ts
+++ b/lib/sanity.ts
@@ -1,4 +1,4 @@
-import imageUrlBuilder from '@sanity/image-url'
+import { createImageUrlBuilder } from '@sanity/image-url'
 import { createHighlighter } from 'shiki';
 import { createClient } from "next-sanity";
 import { cacheLife } from "next/cache";
@@ -11,7 +11,19 @@ export const client = createClient({
   useCdn: false,
 });
 
-const builder = imageUrlBuilder(client)
+const builder = createImageUrlBuilder(client)
+
+let _highlighterPromise: ReturnType<typeof createHighlighter> | null = null;
+
+function getHighlighter(): ReturnType<typeof createHighlighter> {
+  if (!_highlighterPromise) {
+    _highlighterPromise = createHighlighter({
+      themes: ['github-dark', 'github-light'],
+      langs: ['javascript', 'typescript', 'python', 'go', 'rust', 'bash', 'json', 'css', 'html', 'jsx', 'cpp', 'c', 'scss', 'sql', 'tsx', 'xml', 'yaml', 'csharp', 'java', 'markdown', 'php', 'ruby', 'sass', 'text']
+    });
+  }
+  return _highlighterPromise;
+}
 
 export async function getSiteSettings(): Promise<SiteSettings> {
   'use cache'
@@ -266,10 +278,7 @@ export async function getPostBySlug(slug: string): Promise<Post | null> {
   }`;
   const data = await client.fetch(query, { slug });
   if (data?.body) {
-    const highlighter = await createHighlighter({
-      themes: ['github-dark', 'github-light'],
-      langs: ['javascript', 'typescript', 'python', 'go', 'rust', 'bash', 'json', 'css', 'html', 'jsx', 'cpp', 'c', 'scss', 'sql', 'tsx', 'xml', 'yaml', 'csharp', 'java', 'markdown', 'php', 'ruby', 'sass', 'text']
-    });
+    const highlighter = await getHighlighter();
     const langMap: Record<string, string> = {
       javascript: 'javascript',
       js: 'javascript',


### PR DESCRIPTION
- Replace deprecated @sanity/image-url default export with the named createImageUrlBuilder export (lib/sanity.ts)
- Hoist Shiki createHighlighter call to a module-scoped singleton via getHighlighter() to avoid creating one instance per post during static generation (lib/sanity.ts)
- Add block.code component to PortableTextComponents to handle Sanity blocks with style "code" rendered via @portabletext/react (components/PortableTextComponents.tsx)
- Add personal views disclaimer to the blog listing page and paginated blog pages using the same muted italic treatment already applied to individual post pages (app/blog/page.tsx, app/blog/page/[page]/page.tsx)